### PR TITLE
Added a public method to retrieve the original adapter

### DIFF
--- a/src/GaufretteExtras/Adapter/ResolvableAdapter.php
+++ b/src/GaufretteExtras/Adapter/ResolvableAdapter.php
@@ -61,4 +61,9 @@ class ResolvableAdapter implements AdapterInterface, ResolverInterface
     {
         return $this->adapter->isDirectory($key);
     }
+
+    public function getOriginalAdapter()
+    {
+        return $this->adapter;
+    }
 }


### PR DESCRIPTION
I've found I needed the original adapter in order to work with some of the optional interfaces, eg. `MetadataSupporter`. 
